### PR TITLE
Redesign layout for persistent counters and 16:9 frame

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,22 +24,23 @@
       </nav>
     </header>
 
+    <div class="status-bar">
+      <div class="status-item">
+        <span class="status-label">APC :</span>
+        <span class="status-value" id="atoms-per-click">0</span>
+      </div>
+      <div class="status-item status-item-center">
+        <span class="status-label">Atomes</span>
+        <span class="status-value" id="atoms-total">0</span>
+      </div>
+      <div class="status-item status-item-right">
+        <span class="status-label">APS :</span>
+        <span class="status-value" id="atoms-per-sec">0</span>
+      </div>
+    </div>
+
     <main class="view-container">
       <section id="view-atomes" class="view active">
-        <div class="stats-panel">
-          <div class="stat">
-            <span class="label">Atomes</span>
-            <span class="value" id="atoms-total">0</span>
-          </div>
-          <div class="stat">
-            <span class="label">APS</span>
-            <span class="value" id="atoms-per-sec">0</span>
-          </div>
-          <div class="stat">
-            <span class="label">APC</span>
-            <span class="value" id="atoms-per-click">0</span>
-          </div>
-        </div>
         <div class="atom-playground">
           <img src="Assets/Image/Atom.png" alt="Atom" id="atom-button" />
           <p class="hint">Cliquez n'importe où dans la zone pour générer des atomes.</p>

--- a/styles.css
+++ b/styles.css
@@ -22,6 +22,10 @@ body {
   background: var(--bg-main);
   min-height: 100vh;
   overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2vh 2vw;
 }
 
 #starfield {
@@ -79,18 +83,28 @@ body {
   z-index: 1;
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
-  backdrop-filter: blur(4px);
+  width: min(1200px, 92vw, calc(92vh * (16 / 9)));
+  aspect-ratio: 16 / 9;
+  max-height: 92vh;
+  backdrop-filter: blur(10px);
+  background: linear-gradient(135deg, rgba(8, 12, 32, 0.88), rgba(3, 6, 18, 0.76));
+  border: var(--border-neon);
+  border-radius: 24px;
+  box-shadow: 0 25px 40px rgba(0, 0, 0, 0.35), var(--shadow-glow);
+  overflow: hidden;
 }
 
 .top-bar {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 1rem 2rem;
-  background: rgba(3, 6, 18, 0.8);
+  padding: 0.85rem 1.8rem;
+  background: rgba(3, 6, 18, 0.85);
   border-bottom: var(--border-neon);
-  box-shadow: var(--shadow-glow);
+  box-shadow: inset 0 -1px 0 rgba(54, 248, 255, 0.2);
+  flex: 0 0 auto;
+  position: relative;
+  z-index: 3;
 }
 
 .brand {
@@ -105,6 +119,8 @@ body {
 .main-nav {
   display: flex;
   gap: 0.75rem;
+  flex-wrap: wrap;
+  justify-content: center;
 }
 
 .nav-btn {
@@ -133,63 +149,93 @@ body {
   box-shadow: 0 0 12px rgba(54, 248, 255, 0.45);
 }
 
+.status-bar {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.75rem;
+  padding: 0.55rem 1.8rem;
+  background: rgba(12, 18, 42, 0.75);
+  border-bottom: var(--border-neon);
+  box-shadow: inset 0 -1px 0 rgba(54, 248, 255, 0.18);
+  font-family: 'Orbitron', sans-serif;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  flex: 0 0 auto;
+  position: relative;
+  z-index: 2;
+}
+
+.status-item {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 0.45rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 12px;
+  background: rgba(4, 8, 20, 0.75);
+  border: 1px solid rgba(54, 248, 255, 0.2);
+  box-shadow: inset 0 0 10px rgba(54, 248, 255, 0.12);
+  white-space: nowrap;
+}
+
+.status-item-center {
+  justify-content: center;
+}
+
+.status-item-right {
+  justify-content: flex-end;
+}
+
+.status-label {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+.status-value {
+  font-size: 0.95rem;
+  color: var(--accent);
+  text-shadow: 0 0 6px rgba(54, 248, 255, 0.5);
+}
+
 .view-container {
   flex: 1;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: center;
-  padding: 2rem;
+  padding: 1.8rem 1.8rem 1.6rem;
+  overflow-y: auto;
+  position: relative;
+}
+
+.view-container::-webkit-scrollbar {
+  width: 8px;
+}
+
+.view-container::-webkit-scrollbar-track {
+  background: rgba(6, 10, 24, 0.6);
+}
+
+.view-container::-webkit-scrollbar-thumb {
+  background: rgba(54, 248, 255, 0.35);
+  border-radius: 999px;
 }
 
 .view {
   display: none;
   flex-direction: column;
   gap: 2rem;
-  width: min(1100px, 90vw);
-  background: var(--bg-panel);
+  width: min(920px, 100%);
+  background: rgba(8, 14, 34, 0.78);
   border: var(--border-neon);
   border-radius: 20px;
-  padding: 2.5rem;
+  padding: 2.2rem;
   box-shadow: var(--shadow-glow);
-  backdrop-filter: blur(8px);
-  min-height: 60vh;
+  backdrop-filter: blur(12px);
+  min-height: 100%;
 }
 
 .view.active {
   display: flex;
-}
-
-.stats-panel {
-  display: flex;
-  gap: 1.5rem;
-  justify-content: center;
-  flex-wrap: wrap;
-}
-
-.stat {
-  background: rgba(10, 20, 40, 0.7);
-  border: var(--border-neon);
-  border-radius: 16px;
-  padding: 1rem 1.6rem;
-  text-align: center;
-  min-width: 160px;
-  box-shadow: inset 0 0 15px rgba(54, 248, 255, 0.15);
-}
-
-.stat .label {
-  font-size: 0.9rem;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  color: var(--text-secondary);
-}
-
-.stat .value {
-  display: block;
-  font-family: 'Orbitron', sans-serif;
-  font-size: 1.8rem;
-  margin-top: 0.25rem;
-  color: var(--accent);
-  text-shadow: 0 0 10px rgba(54, 248, 255, 0.6);
 }
 
 .atom-playground {
@@ -334,32 +380,53 @@ body {
   transform: translateY(-2px) scale(1.02);
 }
 
-@media (max-width: 900px) {
-  .top-bar {
-    flex-direction: column;
-    gap: 0.8rem;
-  }
-
-  .main-nav {
-    flex-wrap: wrap;
-    justify-content: center;
+@media (max-width: 1024px) {
+  .app-shell {
+    width: min(92vw, calc(92vh * (16 / 9)));
   }
 
   .view {
-    padding: 1.8rem;
+    padding: 1.9rem;
+  }
+}
+
+@media (max-width: 780px) {
+  .status-bar {
+    padding: 0.45rem 1.2rem;
+    gap: 0.45rem;
+  }
+
+  .status-item {
+    padding: 0.25rem 0.55rem;
+  }
+
+  .status-label {
+    font-size: 0.7rem;
+  }
+
+  .status-value {
+    font-size: 0.85rem;
+  }
+
+  .view {
+    padding: 1.6rem;
   }
 }
 
 @media (max-width: 600px) {
   body {
-    overflow: auto;
+    padding: 1.2rem;
   }
 
-  .view {
-    min-height: auto;
+  .app-shell {
+    width: min(100vw - 1.2rem, calc((100vh - 1.2rem) * (16 / 9)));
+  }
+
+  .view-container {
+    padding: 1.3rem 1.2rem;
   }
 
   #atom-button {
-    width: 70vw;
+    width: min(65vw, 260px);
   }
 }


### PR DESCRIPTION
## Summary
- wrap the shell in a fixed 16:9 frame and make the view area scrollable so a vertical slider appears when content overflows
- move the APC, total atoms, and APS counters into a compact status bar that stays visible under the main menu
- refresh styling to keep the header and counters anchored while supporting the redesigned layout

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf2d41c644832ea317a5b0b890520b